### PR TITLE
Add SunOS 5.10 compatability (tar, cd, gzip)

### DIFF
--- a/sshrc
+++ b/sshrc
@@ -6,7 +6,7 @@ function sshrc() {
         if [ -d $SSHHOME/.sshrc.d ]; then
             files="$files .sshrc.d"
         fi
-        SIZE=$(tar cfz - -h -C $SSHHOME $files | wc -c)
+        SIZE=$( { cd $SSHHOME; tar cf - -h $files; } | gzip | wc -c )
         if [ $SIZE -gt 65536 ]; then
             echo >&2 $'.sshrc.d and .sshrc files must be less than 64kb\ncurrent size: '$SIZE' bytes'
             exit 1
@@ -57,7 +57,7 @@ EOF
                 )"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/bashsshrc
             chmod +x \$SSHHOME/bashsshrc
 
-            echo $'"$(tar czf - -h -C $SSHHOME $files | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d | tar mxzf - -C \$SSHHOME
+            echo $'"$( { cd $SSHHOME; tar cf - -h $files; } | gzip | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d | gunzip | { cd \$SSHHOME; tar mxf -; }
             export SSHHOME=\$SSHHOME
             echo \"$CMDARG\" >> \$SSHHOME/sshrc.bashrc
             bash --rcfile \$SSHHOME/sshrc.bashrc


### PR DESCRIPTION
These changes allow for sshrc to work with SunOS 5.10 as that version does not have all the current day flags that tar has. This will give greater compatability and may improve other compatability. This converts from:
tar cfz - -h -C $SSHHOME $files
to
{ cd $SSHHOME; tar cf - -h $files; } | gzip
and reverses the order (gunzip followed by untar) for the final unpack.